### PR TITLE
:sparkles: DDSK-Haskell

### DIFF
--- a/Haskell/Dockerfile
+++ b/Haskell/Dockerfile
@@ -1,0 +1,13 @@
+FROM haskell:9
+
+WORKDIR /work
+
+COPY ./ddsk.hs .
+
+RUN cabal update
+
+RUN cabal install --lib random
+
+RUN ghc -o ./ddsk ./ddsk.hs
+
+ENTRYPOINT ["./ddsk"]

--- a/Haskell/README.md
+++ b/Haskell/README.md
@@ -1,1 +1,15 @@
 # DDSK-Haskell
+
+### How to run
+
+### Docker
+
+1.
+```
+docker build -t ddsk:haskell .
+```
+
+2.
+```
+docker run --rm ddsk:haskell
+```

--- a/Haskell/README.md
+++ b/Haskell/README.md
@@ -4,12 +4,12 @@
 
 ### Docker
 
-1.
+1. Create a Docker image
 ```
 docker build -t ddsk:haskell .
 ```
 
-2.
+2. Execute the program with `docker run`
 ```
 docker run --rm ddsk:haskell
 ```

--- a/Haskell/README.md
+++ b/Haskell/README.md
@@ -1,0 +1,1 @@
+# DDSK-Haskell

--- a/Haskell/ddsk.hs
+++ b/Haskell/ddsk.hs
@@ -21,4 +21,4 @@ nextDdsk (_:xs) str = xs ++ [str]
 
 isDdsk :: [String] -> [String] -> [String] -> ([String], [String])
 isDdsk currstr (x:xs) logs | currstr == ddskstr   = (currstr, logs ++ currstr)
-                           | otherwise            = isDdsk (nextDdsk currstr x) xs (logs ++ currstr)
+                           | otherwise            = isDdsk (nextDdsk currstr x) xs $ logs ++ currstr

--- a/Haskell/ddsk.hs
+++ b/Haskell/ddsk.hs
@@ -2,21 +2,16 @@ import System.Random
 import Control.Monad
 
 main = do
-    g    <- newStdGen       -- get a new random generator
+    g <- newStdGen
     let args = ["ドド", "スコ"]
-
     let ns   = randomRs (0,length args-1) g
         strs = map (args !!) ns
-
     let (_, res) = isDdsk initstr strs []
     mapM_ putStr res
     putStr "ラブ注入♡"
 
-
-
 initstr :: [String]
 initstr = ["X", "X", "X", "X", "X", "X", "X", "X", "X", "X", "X", "X"]
-
 
 ddskstr :: [String]
 ddskstr = ["ドド", "スコ", "スコ", "スコ", "ドド", "スコ", "スコ", "スコ", "ドド", "スコ", "スコ", "スコ"]

--- a/Haskell/ddsk.hs
+++ b/Haskell/ddsk.hs
@@ -1,0 +1,19 @@
+import System.Random
+import Control.Monad
+import System.Environment
+
+main = do
+    g    <- newStdGen       -- get a new random generator
+    -- args <- getArgs         -- get the arguments
+    let args = ["ドド", "スコ"]
+
+    -- do some error checking
+    when (null args) $ print "Usage: ./a.out [arg1 ... argn]"
+
+    -- generate an infinite list of random numbers
+    -- and now use them to generate an infinite list of strings 
+    -- print them out
+
+    let ns   = randomRs (0,length args-1) g
+        strs = map (args !!) ns
+    mapM_ putStrLn strs

--- a/Haskell/ddsk.hs
+++ b/Haskell/ddsk.hs
@@ -8,7 +8,7 @@ main = do
         strs = map (args !!) ns
     let (_, res) = isDdsk initstr strs []
     mapM_ putStr res
-    putStr "ラブ注入♡"
+    putStrLn "ラブ注入♡"
 
 initstr :: [String]
 initstr = ["X", "X", "X", "X", "X", "X", "X", "X", "X", "X", "X", "X"]

--- a/Haskell/ddsk.hs
+++ b/Haskell/ddsk.hs
@@ -20,5 +20,5 @@ nextDdsk :: [String] -> String -> [String]
 nextDdsk (_:xs) str = xs ++ [str]
 
 isDdsk :: [String] -> [String] -> [String] -> ([String], [String])
-isDdsk currstr (x:xs) logs | currstr == ddskstr   = (currstr, logs ++ currstr)
-                           | otherwise            = isDdsk (nextDdsk currstr x) xs $ logs ++ currstr
+isDdsk currstr (x:xs) logs | currstr == ddskstr   = (currstr, logs)
+                           | otherwise            = isDdsk (nextDdsk currstr x) xs $ logs ++ [x]

--- a/Haskell/ddsk.hs
+++ b/Haskell/ddsk.hs
@@ -7,7 +7,9 @@ main = do
 
     let ns   = randomRs (0,length args-1) g
         strs = map (args !!) ns
-    mapM_ putStr (isDdsk initstr strs)
+
+    let (_, res) = isDdsk initstr strs []
+    mapM_ putStr res
     putStr "ラブ注入♡"
 
 
@@ -22,6 +24,6 @@ ddskstr = ["ドド", "スコ", "スコ", "スコ", "ドド", "スコ", "スコ",
 nextDdsk :: [String] -> String -> [String]
 nextDdsk (_:xs) str = xs ++ [str]
 
-isDdsk :: [String] -> [String] -> [String]
-isDdsk currstr (x:xs) | currstr == ddskstr   = currstr
-                      | otherwise            = isDdsk (nextDdsk currstr x) xs
+isDdsk :: [String] -> [String] -> [String] -> ([String], [String])
+isDdsk currstr (x:xs) logs | currstr == ddskstr   = (currstr, logs ++ currstr)
+                           | otherwise            = isDdsk (nextDdsk currstr x) xs (logs ++ currstr)

--- a/Haskell/ddsk.hs
+++ b/Haskell/ddsk.hs
@@ -1,19 +1,27 @@
 import System.Random
 import Control.Monad
-import System.Environment
 
 main = do
     g    <- newStdGen       -- get a new random generator
-    -- args <- getArgs         -- get the arguments
     let args = ["ドド", "スコ"]
-
-    -- do some error checking
-    when (null args) $ print "Usage: ./a.out [arg1 ... argn]"
-
-    -- generate an infinite list of random numbers
-    -- and now use them to generate an infinite list of strings 
-    -- print them out
 
     let ns   = randomRs (0,length args-1) g
         strs = map (args !!) ns
-    mapM_ putStrLn strs
+    mapM_ putStr (isDdsk initstr strs)
+    putStr "ラブ注入♡"
+
+
+
+initstr :: [String]
+initstr = ["X", "X", "X", "X", "X", "X", "X", "X", "X", "X", "X", "X"]
+
+
+ddskstr :: [String]
+ddskstr = ["ドド", "スコ", "スコ", "スコ", "ドド", "スコ", "スコ", "スコ", "ドド", "スコ", "スコ", "スコ"]
+
+nextDdsk :: [String] -> String -> [String]
+nextDdsk (_:xs) str = xs ++ [str]
+
+isDdsk :: [String] -> [String] -> [String]
+isDdsk currstr (x:xs) | currstr == ddskstr   = currstr
+                      | otherwise            = isDdsk (nextDdsk currstr x) xs


### PR DESCRIPTION
Haskellでドドスコの実装をできるだけ簡単な構文を使用して行いました。乱数を生成する部分と関数 isDdsk によって得られた結果に添えて「ラブ注入♡」を表示する部分の2つを手続き的に書き、ドドスコを判定するプログラムを関数として切り出して実装しました。
- このプログラムでは停止するために必要なだけ乱数を生成する必要がありますが、これを乱数の無限リストをあらかじめ作っておくことで実現しました。
- 判定部ではパターンマッチと再帰的な関数呼び出しを用いてドドスコの判定を行っています。